### PR TITLE
auto-renaming of datadir

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -656,7 +656,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     printf("Using OpenSSL version %s\n", SSLeay_version(SSLEAY_VERSION));
     if (!fLogTimestamps)
         printf("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
-    printf("Default data directory %s\n", GetDefaultDataDir().string().c_str());
+    printf("Default data directory %s\n", GetDefaultDataDir(false).string().c_str());
     printf("Using data directory %s\n", strDataDir.c_str());
     printf("Using at most %i connections (%i file descriptors available)\n", nMaxConnections, nFD);
     std::ostringstream strErrors;

--- a/src/util.h
+++ b/src/util.h
@@ -207,7 +207,7 @@ bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
 bool RenameOver(boost::filesystem::path src, boost::filesystem::path dest);
-boost::filesystem::path GetDefaultDataDir();
+boost::filesystem::path GetDefaultDataDir(bool fWalletDirUpgrade);
 const boost::filesystem::path &GetDataDir(bool fNetSpecific = true);
 boost::filesystem::path GetConfigFile();
 boost::filesystem::path GetPidFile();


### PR DESCRIPTION
Automatically renames the old datadir to the new one during first run of the new wallet.
Did some initial testing on Linux, MacOSX and Windows still need to be tested.
